### PR TITLE
feat: add option for augmenting ServiceId type

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -1,0 +1,94 @@
+name: Pull Requests
+
+on:
+  pull_request:
+
+jobs:
+  Install:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - uses: actions/cache@v2
+        id: cache-node_modules
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+      - if: steps.cache-node_modules.outputs.cache-hit != 'true'
+        run: npm ci
+
+  Test:
+    needs:
+      - Install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - uses: actions/cache@v2
+        id: cache-node_modules
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+      - run: npm run test
+
+  Lint:
+    needs:
+      - Install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - uses: actions/cache@v2
+        id: cache-node_modules
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+      - run: npm run lint
+
+  Typecheck:
+    needs:
+      - Install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - uses: actions/cache@v2
+        id: cache-node_modules
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+      - run: npm run typecheck
+
+  Build:
+    needs:
+      - Install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - uses: actions/cache@v2
+        id: cache-node_modules
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+      - run: npm run build

--- a/README.md
+++ b/README.md
@@ -43,6 +43,29 @@ ReactDOM.render(
 )
 ```
 
+### Type-checks for service id
+
+Service-specific code needs to target a specific `serviceId`, for example
+to check its consent status. You can augment this interface to override
+the default `string` type with an `enum` to support stricted type-level
+checks in your application code. You should create an enum containing
+all your configured `serviceId`s.
+
+```ts
+import '@s-group/react-usercentrics'
+
+enum MyServiceIdEnum {
+  Service1 = 'service-id-1'
+  Service2 = 'service-id-2'
+}
+
+declare module '@s-group/react-usercentrics' {
+  export interface Augmented {
+    serviceId: MyServiceIdEnum
+  }
+}
+```
+
 ## API
 
 ### Components

--- a/src/hooks/use-has-service-consent.ts
+++ b/src/hooks/use-has-service-consent.ts
@@ -1,3 +1,4 @@
+import type { ServiceId } from '../types.js'
 import { hasServiceConsent } from '../utils.js'
 import { useServiceDebug } from './use-service-debug.js'
 import { useServiceInfo } from './use-service-info.js'
@@ -6,7 +7,7 @@ import { useServiceInfo } from './use-service-info.js'
  * Returns `true` if the specific Usercentrics service has been given consent.
  * If it returns `false`, the service should not be loaded or used.
  */
-export const useHasServiceConsent = (serviceId: string): boolean => {
+export const useHasServiceConsent = (serviceId: ServiceId): boolean => {
     useServiceDebug(serviceId)
     const serviceInfo = useServiceInfo(serviceId)
     return hasServiceConsent(serviceInfo)

--- a/src/hooks/use-service-debug.ts
+++ b/src/hooks/use-service-debug.ts
@@ -1,9 +1,10 @@
 import { useContext, useDebugValue, useEffect } from 'react'
 
 import { UsercentricsContext } from '../context.js'
+import type { ServiceId } from '../types.js'
 import { getServicesBaseInfo } from '../utils.js'
 
-export const useServiceDebug = (serviceId: string) => {
+export const useServiceDebug = (serviceId: ServiceId) => {
     const { isInitialized, ping, strictMode } = useContext(UsercentricsContext)
 
     useDebugValue(getServicesBaseInfo(), (services) => services.find(({ id }) => serviceId === id))

--- a/src/hooks/use-service-info.ts
+++ b/src/hooks/use-service-info.ts
@@ -1,7 +1,7 @@
 import { useContext, useEffect, useState } from 'react'
 
 import { UsercentricsContext } from '../context.js'
-import type { ServiceFullInfo, ServiceInfo } from '../types.js'
+import type { ServiceFullInfo, ServiceId, ServiceInfo } from '../types.js'
 import { getServicesBaseInfo, getServicesFullInfo } from '../utils.js'
 import { useServiceDebug } from './use-service-debug.js'
 
@@ -16,7 +16,7 @@ import { useServiceDebug } from './use-service-debug.js'
  *
  * @see https://docs.usercentrics.com/#/cmp-v2-ui-api?id=getservicesbaseinfo
  */
-export const useServiceInfo = (serviceId: string): ServiceInfo | null => {
+export const useServiceInfo = (serviceId: ServiceId): ServiceInfo | null => {
     useServiceDebug(serviceId)
     return getServicesBaseInfo().find(({ id }) => serviceId === id) || null
 }
@@ -34,7 +34,7 @@ export const useServiceInfo = (serviceId: string): ServiceInfo | null => {
  *
  * @see https://docs.usercentrics.com/#/cmp-v2-ui-api?id=getservicesfullinfo
  */
-export const useServiceFullInfo = (serviceId: string): ServiceFullInfo | null => {
+export const useServiceFullInfo = (serviceId: ServiceId): ServiceFullInfo | null => {
     useServiceDebug(serviceId)
 
     const { ping } = useContext(UsercentricsContext)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,40 @@
+/**
+ * Service-specific code needs to target a specific `serviceId`, for example
+ * to check its consent status. You can augment a special interface to override
+ * the default `string` type with an `enum` to support stricted type-level
+ * checks in your application code. You should create an enum containing
+ * all your configured `serviceId`s.
+ *
+ * @example
+ *
+ * ```
+ * import '@s-group/react-usercentrics'
+ *
+ * enum MyServiceIdEnum {
+ *   Service1 = 'service-id-1'
+ *   Service2 = 'service-id-2'
+ * }
+ *
+ * declare module '@s-group/react-usercentrics' {
+ *   export interface Augmented {
+ *     serviceId: MyServiceIdEnum
+ *   }
+ * }
+ * ```
+ *
+ * @default string
+ *
+ * @see https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
+ */
+export interface Augmented {
+    serviceId: string
+}
+
+export type ServiceId = Augmented['serviceId']
+
 /** Partial type for a service's base info. Unused values are left out. */
 export type ServiceInfo = {
-    id: string
+    id: ServiceId
     name: string
     consent: {
         status: boolean
@@ -59,13 +93,13 @@ type UC_UI = {
      *
      * @see https://docs.usercentrics.com/#/cmp-v2-ui-api?id=showsecondlayer
      */
-    showSecondLayer?: (serviceId?: string) => void
+    showSecondLayer?: (serviceId?: ServiceId) => void
 
     /**
      * A method for accepting a single service.
      * @see https://docs.usercentrics.com/#/cmp-v2-ui-api?id=acceptservice
      */
-    acceptService?: (serviceId: string, consentType?: ConsentType) => Promise<void>
+    acceptService?: (serviceId: ServiceId, consentType?: ConsentType) => Promise<void>
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 const IS_BROWSER = typeof window !== 'undefined'
 
-import type { ConsentType, ServiceFullInfo, ServiceInfo, UCWindow } from './types.js'
+import type { ConsentType, ServiceFullInfo, ServiceId, ServiceInfo, UCWindow } from './types.js'
 
 /**
  * Programmatic way to show First Layer.
@@ -25,7 +25,7 @@ export const showFirstLayer = (): void => {
  *
  * @see https://docs.usercentrics.com/#/cmp-v2-ui-api?id=showsecondlayer
  */
-export const showSecondLayer = (serviceId?: string): void => {
+export const showSecondLayer = (serviceId?: ServiceId): void => {
     if (IS_BROWSER) {
         ;(window as UCWindow).UC_UI?.showSecondLayer?.(serviceId)
     }
@@ -56,7 +56,7 @@ export const hasServiceConsent = (service: ServiceInfo | null): boolean => !!ser
  * A method for accepting a single service.
  * @see https://docs.usercentrics.com/#/cmp-v2-ui-api?id=acceptservice
  */
-export const acceptService = async (serviceId: string, consentType?: ConsentType) => {
+export const acceptService = async (serviceId: ServiceId, consentType?: ConsentType) => {
     if (IS_BROWSER) {
         await (window as UCWindow).UC_UI?.acceptService?.(serviceId, consentType)
     }


### PR DESCRIPTION
The default `string` type can be augmented to be an `enum` instead
to get stricter type-level checks. See the `README.md` for an example.