### PR TITLE
fix(ci): update GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,11 +9,11 @@ jobs:
   Install:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16
-      - uses: actions/cache@v2
+          node-version: 18
+      - uses: actions/cache@v3
         id: cache-node_modules
         with:
           path: node_modules
@@ -28,11 +28,11 @@ jobs:
       - Install
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16
-      - uses: actions/cache@v2
+          node-version: 18
+      - uses: actions/cache@v3
         id: cache-node_modules
         with:
           path: node_modules
@@ -46,11 +46,11 @@ jobs:
       - Install
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16
-      - uses: actions/cache@v2
+          node-version: 18
+      - uses: actions/cache@v3
         id: cache-node_modules
         with:
           path: node_modules
@@ -64,11 +64,11 @@ jobs:
       - Install
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16
-      - uses: actions/cache@v2
+          node-version: 18
+      - uses: actions/cache@v3
         id: cache-node_modules
         with:
           path: node_modules
@@ -82,11 +82,11 @@ jobs:
       - Install
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16
-      - uses: actions/cache@v2
+          node-version: 18
+      - uses: actions/cache@v3
         id: cache-node_modules
         with:
           path: node_modules
@@ -105,13 +105,13 @@ jobs:
       - Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16
-      - uses: actions/cache@v2
+          node-version: 18
+      - uses: actions/cache@v3
         id: cache-node_modules
         with:
           path: node_modules

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -7,11 +7,11 @@ jobs:
   Install:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16
-      - uses: actions/cache@v2
+          node-version: 18
+      - uses: actions/cache@v3
         id: cache-node_modules
         with:
           path: node_modules
@@ -26,11 +26,11 @@ jobs:
       - Install
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16
-      - uses: actions/cache@v2
+          node-version: 18
+      - uses: actions/cache@v3
         id: cache-node_modules
         with:
           path: node_modules
@@ -44,11 +44,11 @@ jobs:
       - Install
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16
-      - uses: actions/cache@v2
+          node-version: 18
+      - uses: actions/cache@v3
         id: cache-node_modules
         with:
           path: node_modules
@@ -62,11 +62,11 @@ jobs:
       - Install
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16
-      - uses: actions/cache@v2
+          node-version: 18
+      - uses: actions/cache@v3
         id: cache-node_modules
         with:
           path: node_modules
@@ -80,11 +80,11 @@ jobs:
       - Install
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16
-      - uses: actions/cache@v2
+          node-version: 18
+      - uses: actions/cache@v3
         id: cache-node_modules
         with:
           path: node_modules

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,11 @@ jobs:
   Install:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 14
-      - uses: actions/cache@v2
+          node-version: 18
+      - uses: actions/cache@v3
         id: cache-node_modules
         with:
           path: node_modules
@@ -29,14 +29,14 @@ jobs:
     needs: Install
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           registry-url: https://registry.npmjs.org
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: cache-node_modules
         with:
           path: node_modules


### PR DESCRIPTION
This PR updates the GitHub Actions' versions to make releasing work with the new npm lockfile format v3.