### PR TITLE
feat: the `useHasServiceConsent` hook returns `null` if consent statu…

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,10 @@ interface UsercentricsDialogToggleProps extends ButtonHTMLAttributes<HTMLButtonE
 
 #### `useHasServiceConsent`
 
-Returns `true` if the specific Usercentrics service has been given consent.
-If it returns `false`, the service should not be loaded or used.
+Whether the specific Usercentrics service has been given consent.
+Returns `true` or `false` based on consent status, or `null` when unknown (not yet loaded).
+
+ **Warning:** it's best to assume no consent until this hook returns `true`
 
 ```tsx
 () => {

--- a/src/hooks/use-has-service-consent.ts
+++ b/src/hooks/use-has-service-consent.ts
@@ -7,17 +7,23 @@ import { useServiceDebug } from './use-service-debug.js'
 import { useServiceInfo } from './use-service-info.js'
 
 /**
- * Returns `true` if the specific Usercentrics service has been given consent.
- * If it returns `false`, the service should not be loaded or used.
+ * Whether the specific Usercentrics service has been given consent.
+ * Returns `true` or `false` based on consent status, or `null` when unknown (not yet loaded).
+ *
+ * @warn it's best to assume no consent until this hook returns `true`
  */
-export const useHasServiceConsent = (serviceId: ServiceId): boolean => {
+export const useHasServiceConsent = (serviceId: ServiceId): boolean | null => {
     useServiceDebug(serviceId)
     const serviceInfo = useServiceInfo(serviceId)
     const { isInitialized, localStorageState } = useContext(UsercentricsContext)
 
-    /** Until Usercentrics CMP has loaded, try to get consent status from localStorage */
+    /**
+     * Until Usercentrics CMP has loaded, try to get consent status from localStorage.
+     * If it's not loaded, and there's nothing in localStorage, this will return `null`
+     */
     if (!isInitialized) {
-        return !!localStorageState.find((service) => service.id === serviceId)?.status
+        const saved = localStorageState.find((service) => service.id === serviceId)
+        return saved ? saved.status : null
     }
 
     return hasServiceConsent(serviceInfo)

--- a/tests/hooks/use-has-service-consent.test.tsx
+++ b/tests/hooks/use-has-service-consent.test.tsx
@@ -34,14 +34,14 @@ describe('Usercentrics', () => {
                         </UsercentricsContext.Provider>
                     )
 
-            it('should read from localStorage and return false when not initialized', () => {
+            it('should read from localStorage and return null when not initialized and no data', () => {
                 mockUseServiceInfo.mockReturnValue(null)
 
                 const { result } = renderHook(() => useHasServiceConsent('test-id'), {
                     wrapper: getWrapper({ isInitialized: false, localStorageState: [] }),
                 })
 
-                expect(result.current).toEqual(false)
+                expect(result.current).toEqual(null)
             })
 
             it('should read from localStorage and return true when not initialized', () => {


### PR DESCRIPTION
…s is unknown (not yet loaded)

**Warning:** it's best to assume no consent until this hook returns `true`