### PR TITLE
fix: the `useHasServiceConsent` hook works better with SSR hydration

### DIFF
--- a/src/components/UsercentricsProvider.tsx
+++ b/src/components/UsercentricsProvider.tsx
@@ -44,6 +44,11 @@ export const UsercentricsProvider: FC<UsercentricsProviderProps> = ({
     timeout = 5000,
     windowEventName,
 }) => {
+    const [isClientSide, setIsClientSide] = useState(false)
+    useEffect(() => {
+        setIsClientSide(true)
+    }, [])
+
     /**
      * A trivial unique value that should be updated whenever
      * Usercentrics data is updated. This is for making sure
@@ -148,6 +153,7 @@ export const UsercentricsProvider: FC<UsercentricsProviderProps> = ({
     return (
         <UsercentricsContext.Provider
             value={{
+                isClientSide,
                 isFailed,
                 isInitialized,
                 isOpen,

--- a/src/context.ts
+++ b/src/context.ts
@@ -3,6 +3,7 @@ import { createContext } from 'react'
 import { ServiceInfoFromLocalStorage } from './types'
 
 interface UsercentricsContextType {
+    isClientSide: boolean
     isFailed: boolean
     isInitialized: boolean
     isOpen: boolean
@@ -12,6 +13,7 @@ interface UsercentricsContextType {
 }
 
 const INITIAL_STATE: UsercentricsContextType = {
+    isClientSide: false,
     isFailed: false,
     isInitialized: false,
     isOpen: false,

--- a/src/hooks/use-has-service-consent.ts
+++ b/src/hooks/use-has-service-consent.ts
@@ -15,7 +15,12 @@ import { useServiceInfo } from './use-service-info.js'
 export const useHasServiceConsent = (serviceId: ServiceId): boolean | null => {
     useServiceDebug(serviceId)
     const serviceInfo = useServiceInfo(serviceId)
-    const { isInitialized, localStorageState } = useContext(UsercentricsContext)
+    const { isClientSide, isInitialized, localStorageState } = useContext(UsercentricsContext)
+
+    /** Consent status is unknown during SSR because CMP is only available client-side */
+    if (!isClientSide) {
+        return null
+    }
 
     /**
      * Until Usercentrics CMP has loaded, try to get consent status from localStorage.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 export { UsercentricsDialogToggle } from './components/UsercentricsDialogToggle.js'
 export { UsercentricsProvider } from './components/UsercentricsProvider.js'
 export { UsercentricsScript } from './components/UsercentricsScript.js'
-
 export { useHasServiceConsent } from './hooks/use-has-service-consent.js'
-export { useIsFailed } from './hooks/use-is-failed.js'
+
 export { useIsInitialized } from './hooks/use-is-initialized.js'
+export { useIsFailed } from './hooks/use-is-failed.js'
 export { useIsOpen } from './hooks/use-is-open.js'
 export { useHasUserInteracted } from './hooks/use-has-user-interacted.js'
 export { useServiceFullInfo, useServiceInfo } from './hooks/use-service-info.js'

--- a/tests/hooks/use-has-service-consent.test.tsx
+++ b/tests/hooks/use-has-service-consent.test.tsx
@@ -16,6 +16,7 @@ describe('Usercentrics', () => {
     describe('hooks', () => {
         describe('useHasServiceConsent', () => {
             const CONTEXT: ContextType<typeof UsercentricsContext> = {
+                isClientSide: true,
                 isFailed: false,
                 isInitialized: true,
                 isOpen: false,
@@ -34,7 +35,21 @@ describe('Usercentrics', () => {
                         </UsercentricsContext.Provider>
                     )
 
-            it('should read from localStorage and return null when not initialized and no data', () => {
+            it('should return null during SSR', () => {
+                mockUseServiceInfo.mockReturnValue({
+                    id: 'test-id',
+                    name: 'Salesforce',
+                    consent: { status: true },
+                })
+
+                const { result } = renderHook(() => useHasServiceConsent('test-id'), {
+                    wrapper: getWrapper({ isClientSide: false }),
+                })
+
+                expect(result.current).toEqual(null)
+            })
+
+            it('should return null when not initialized and no localStorage data', () => {
                 mockUseServiceInfo.mockReturnValue(null)
 
                 const { result } = renderHook(() => useHasServiceConsent('test-id'), {
@@ -44,7 +59,7 @@ describe('Usercentrics', () => {
                 expect(result.current).toEqual(null)
             })
 
-            it('should read from localStorage and return true when not initialized', () => {
+            it('should return true when not initialized but localStorage has data', () => {
                 mockUseServiceInfo.mockReturnValue(null)
 
                 const { result } = renderHook(() => useHasServiceConsent('test-id'), {


### PR DESCRIPTION
The previous implementation read status from localStorage on the first render, so whenever client had already given consent the initial render after SSR caused a hydration mismatch.