### PR TITLE
feat: introduce service to manage state

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -4,6 +4,7 @@ module.exports = {
         '^(\\.{1,2}/.*)\\.js$': '$1',
     },
     testEnvironment: 'jsdom',
+    testMatch: ['**/*.(spec|test).(ts|tsx|?js)'],
     transform: {
         '^.+\\.(t|j)sx?$': [
             '@swc/jest',

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     },
     "types": "./dist/index.d.ts",
     "files": [
-        "dist/*",
+        "dist",
         "augmented.d.ts"
     ],
     "sideEffects": false,

--- a/src/components/UsercentricsProvider.tsx
+++ b/src/components/UsercentricsProvider.tsx
@@ -2,11 +2,8 @@ import { FC, ReactNode, useMemo } from 'react'
 import React, { useCallback, useEffect, useState } from 'react'
 
 import { UsercentricsContext } from '../context.js'
-import type { UCUICMPEvent, UCWindow } from '../types.js'
-import { UCUICMPEventType } from '../types.js'
+import { ServiceState, UsercentericsService } from '../services/usercentrics-service.js'
 import { getServicesFromLocalStorage } from '../utils.js'
-
-const isUCUICMPEvent = (event: Event): event is UCUICMPEvent => event.type === 'UC_UI_CMP_EVENT'
 
 interface UsercentricsProviderProps {
     children: ReactNode
@@ -28,27 +25,12 @@ interface UsercentricsProviderProps {
     windowEventName: string
 }
 
-/**
- * The provider component for listening to events from the Usercentrics Browser API.
- * Render this once and wrap your application in it.
- *
- * @example <caption>Basic usage</caption>
- * () => <UsercentricsProvider windowEventName="ucEvent"><App /></UsercentricsProvider>
- *
- * @example <caption>Custom timeout in milliseconds</caption>
- * () => <UsercentricsProvider timeout={100} windowEventName="ucEvent"><App /></UsercentricsProvider>
- */
 export const UsercentricsProvider: FC<UsercentricsProviderProps> = ({
     children,
     strictMode = false,
     timeout = 5000,
     windowEventName,
 }) => {
-    const [isClientSide, setIsClientSide] = useState(false)
-    useEffect(() => {
-        setIsClientSide(true)
-    }, [])
-
     /**
      * A trivial unique value that should be updated whenever
      * Usercentrics data is updated. This is for making sure
@@ -58,91 +40,41 @@ export const UsercentricsProvider: FC<UsercentricsProviderProps> = ({
 
     /** True if Usercentrics failed to load. */
     const [isFailed, setIsFailed] = useState(false)
+    const [state, setState] = useState<ServiceState>(UsercentericsService.getState())
 
     /**
-     * True if the Usercentrics consent management platform
-     * modal is open on the page.
+     * Immutable value must be used from the service, or state update will fail to trigger update react
      */
-    const [isOpen, setIsOpen] = useState(false)
-
-    /**
-     * True if the Usercentrics consent management platform is
-     * initialized and ready to use.
-     */
-    const [isInitialized, setIsInitialized] = useState(false)
-
-    const initializedCallback = useCallback(() => {
-        setIsInitialized(true)
-        pong(Symbol())
-    }, [])
-
-    const ucEventCallback = useCallback(() => {
-        pong(Symbol())
-    }, [])
-
-    const ucUIEventCallback = useCallback((event: Event) => {
-        if (!isUCUICMPEvent(event)) return
-
-        /**
-         * Detect whether the Usercentrics modal is open or closed:
-         *
-         * - if event type was 'CMP_SHOWN', it is open
-         * - if event type was one of 'ACCEPT_ALL', 'DENY_ALL', or
-         *   'SAVE', it means user clicked one of those buttons,
-         *   and so it should now be closed
-         */
-        switch (event.detail.type) {
-            case UCUICMPEventType.CMP_SHOWN:
-                setIsOpen(true)
-                break
-            case UCUICMPEventType.ACCEPT_ALL:
-            case UCUICMPEventType.DENY_ALL:
-            case UCUICMPEventType.SAVE:
-                setIsOpen(false)
-        }
-    }, [])
-
     useEffect(() => {
-        if (isFailed) return
+        const unsub = UsercentericsService.subscribe(setState)
+        return unsub
+    }, [])
 
-        if ((window as UCWindow).UC_UI?.isInitialized?.()) {
-            setIsInitialized(true)
-        }
+    const [isClientSide, setIsClientSide] = useState(false)
+    useEffect(() => setIsClientSide(true), [])
 
-        if (!isInitialized) {
-            /** @see https://docs.usercentrics.com/#/v2-events?id=app-initialization-browser-ui */
-            window.addEventListener('UC_UI_INITIALIZED', initializedCallback)
-        }
+    /**
+     * If user has blocked Usercentrics initialization script, update the var.
+     * Used to eg. allow search using minimal consent options
+     */
+    useEffect(() => {
+        const t = setTimeout(() => {
+            if (!state.initialized) {
+                setIsFailed(true)
+            }
+        }, timeout)
+        return () => clearTimeout(t)
+    }, [state, timeout])
 
+    const ucEventCallback = useCallback(() => pong(Symbol()), [pong])
+    useEffect(() => {
         /**
          * The event name is arbitrary and has to configured in the Admin UI
          * @see https://docs.usercentrics.com/#/v2-events?id=usage-as-window-event
          */
         window.addEventListener(windowEventName, ucEventCallback)
-
-        /** @see https://docs.usercentrics.com/#/v2-events?id=uc_ui_cmp_event */
-        window.addEventListener('UC_UI_CMP_EVENT', ucUIEventCallback)
-
-        /**
-         * If user has blocked Usercentrics initialization script, update the var.
-         * Used to eg. allow search using minimal consent options
-         */
-        let isMounted = true
-        if (!isInitialized) {
-            setTimeout(() => {
-                if (isMounted && !isInitialized) {
-                    setIsFailed(true)
-                }
-            }, timeout)
-        }
-
-        return () => {
-            window.removeEventListener('UC_UI_INITIALIZED', initializedCallback)
-            window.removeEventListener(windowEventName, ucEventCallback)
-            window.removeEventListener('UC_UI_CMP_EVENT', ucUIEventCallback)
-            isMounted = false
-        }
-    }, [initializedCallback, isFailed, isInitialized, timeout, ucEventCallback, ucUIEventCallback, windowEventName])
+        return () => window.removeEventListener(windowEventName, ucEventCallback)
+    }, [ucEventCallback, windowEventName])
 
     /**
      * Try to read current setting from localStorage. These are only used until the CMP has been loaded,
@@ -155,8 +87,8 @@ export const UsercentricsProvider: FC<UsercentricsProviderProps> = ({
             value={{
                 isClientSide,
                 isFailed,
-                isInitialized,
-                isOpen,
+                isInitialized: state.initialized,
+                isOpen: state.isOpen,
                 localStorageState,
                 ping,
                 strictMode,

--- a/src/services/usercentrics-service.ts
+++ b/src/services/usercentrics-service.ts
@@ -1,0 +1,62 @@
+/** State management singleton for internal use. This should not be used directly in applications. */
+
+import { UCUICMPEvent, UCUICMPEventType } from '../types'
+
+export type ServiceState = {
+    initialized: boolean
+    isOpen: boolean
+}
+
+const isUCUICMPEvent = (event: Event): event is UCUICMPEvent => event.type === 'UC_UI_CMP_EVENT'
+
+/**
+ * value needs to be immutable, ie. this cannot be a const as react will need a new object instance to update its state
+ * or this would need to be refactored as part of class or an object
+ */
+let state: ServiceState = {
+    initialized: false,
+    isOpen: false,
+}
+
+const listeners: ((x: ServiceState) => void)[] = []
+const update = () => listeners.forEach((s) => s(state))
+const subscribe = (x: (x: ServiceState) => void): (() => void) => {
+    listeners.push(x)
+    return () => {
+        listeners.indexOf(x) > -1 ? listeners.splice(listeners.indexOf(x), 1) : undefined
+    }
+}
+
+const setIsOpen = (isOpen: boolean) => {
+    state = { ...state, isOpen }
+    update()
+}
+const setIsInitialized = (initialized: boolean) => {
+    state = { ...state, initialized }
+    update()
+}
+
+const onEvent = (event: Event) => {
+    if (isUCUICMPEvent(event)) {
+        switch (event.detail.type) {
+            case UCUICMPEventType.CMP_SHOWN:
+                setIsOpen(true)
+                break
+            case UCUICMPEventType.ACCEPT_ALL:
+            case UCUICMPEventType.DENY_ALL:
+            case UCUICMPEventType.SAVE:
+                setIsOpen(false)
+                break
+        }
+    }
+}
+
+if (typeof window !== 'undefined') {
+    window.addEventListener('UC_UI_CMP_EVENT', onEvent)
+    window.addEventListener('UC_UI_INITIALIZED', () => setIsInitialized(true))
+}
+
+export const UsercentericsService = {
+    getState: () => state,
+    subscribe,
+}

--- a/tests/user-centrics-service.test.ts
+++ b/tests/user-centrics-service.test.ts
@@ -1,0 +1,119 @@
+import { fireEvent } from '@testing-library/react'
+
+import { UCUICMPEventType } from '../src'
+import { ServiceState, UsercentericsService } from '../src/services/usercentrics-service'
+
+describe('User centrics service', () => {
+    it('should subscribe to window events and trigger callback', () => {
+        const f = jest.fn()
+
+        UsercentericsService.subscribe(f)
+
+        fireEvent(window, createEvent(UCUICMPEventType.CMP_SHOWN))
+        expect(f).toHaveBeenCalled()
+    })
+
+    it('state value must not be the same instance', () => {
+        const a = UsercentericsService.getState()
+        fireEvent(window, createEvent(UCUICMPEventType.CMP_SHOWN))
+        const b = UsercentericsService.getState()
+        expect(a === b).toBeFalsy()
+    })
+
+    it('consecutive subscribe state values must not be the same instance', () => {
+        const mockState: { a: ServiceState | null; b: ServiceState | null } = {
+            a: null,
+            b: null,
+        }
+
+        const unsub = UsercentericsService.subscribe((state) => {
+            mockState.a = state
+        })
+        fireEvent(window, createEvent(UCUICMPEventType.CMP_SHOWN))
+
+        // same state is passed to all listeners, not two consecutive states should be equal
+        // so we remove the first listener to not assign value again to 'a'
+        unsub()
+
+        UsercentericsService.subscribe((state) => {
+            mockState.b = state
+        })
+        fireEvent(window, createEvent(UCUICMPEventType.CMP_SHOWN))
+
+        expect(mockState.a).not.toBeNull()
+        expect(mockState.b).not.toBeNull()
+        expect(mockState.a === mockState.b).toBeFalsy()
+    })
+
+    it('should be able to unsubscribe from window events', () => {
+        const f = jest.fn()
+        const f_2 = jest.fn()
+
+        const unsub = UsercentericsService.subscribe(f)
+        UsercentericsService.subscribe(f_2)
+
+        fireEvent(window, createEvent(UCUICMPEventType.CMP_SHOWN))
+        expect(f).toHaveBeenCalledTimes(1)
+        expect(f_2).toHaveBeenCalledTimes(1)
+
+        unsub()
+        fireEvent(window, createEvent(UCUICMPEventType.CMP_SHOWN))
+        expect(f).toHaveBeenCalledTimes(1)
+        expect(f_2).toHaveBeenCalledTimes(2)
+    })
+
+    it('should get updated state on init', () => {
+        fireEvent(window, createEvent(UCUICMPEventType.CMP_SHOWN))
+        expect(UsercentericsService.getState()).toEqual(createState({ isOpen: true }))
+    })
+
+    it('should set state to open', () => {
+        const f = jest.fn()
+
+        UsercentericsService.subscribe(f)
+
+        fireEvent(window, createEvent(UCUICMPEventType.CMP_SHOWN))
+        expect(f).toHaveBeenCalledWith(createState({ isOpen: true }))
+    })
+
+    it('should set state to closed', () => {
+        const f = jest.fn()
+
+        UsercentericsService.subscribe(f)
+
+        fireEvent(window, createEvent(UCUICMPEventType.ACCEPT_ALL))
+        expect(f).toHaveBeenCalledWith(createState({ isOpen: false }))
+    })
+
+    it('should set state to closed', () => {
+        const f = jest.fn()
+
+        UsercentericsService.subscribe(f)
+
+        fireEvent(window, createEvent(UCUICMPEventType.DENY_ALL))
+        expect(f).toHaveBeenCalledWith(createState({ isOpen: false }))
+    })
+
+    it('should set state to closed', () => {
+        const f = jest.fn()
+
+        UsercentericsService.subscribe(f)
+
+        fireEvent(window, createEvent(UCUICMPEventType.SAVE))
+        expect(f).toHaveBeenCalledWith(createState({ isOpen: false }))
+    })
+})
+
+const createEvent = (type: UCUICMPEventType) => {
+    const e = new Event('UC_UI_CMP_EVENT') as Event & { detail: { type: UCUICMPEventType } }
+    e.detail = {
+        type,
+    }
+    return e
+}
+
+const createState = (x: Partial<ServiceState>): ServiceState => ({
+    initialized: false,
+    isOpen: false,
+    ...x,
+})


### PR DESCRIPTION
add service to keep track of the current state of the user-centrics as react can be initialized long after the events have been fired

also increase timeout since 5s is a bit too short on dev.