### PR TITLE
fix: change from version to draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,11 @@ interface UsercentricsScriptProps
     settingsId: string
 
     /**
-     * Whether to run Usercentrics in "production" or "preview" mode
-     * @default "production"
+     * Whether to run Usercentrics in draft mode
+     * @default `false`
+     * @see https://usercentrics.com/docs/web/implementation/ui/optional-steps/#draft-script
      */
-    version?: 'production' | 'preview'
+    draft?: boolean
 
     src?: never
 }
@@ -114,7 +115,7 @@ interface UsercentricsScriptProps
 ;() => <UsercentricsScript settingsId="1234" />
 
 /** Preview mode for development */
-;() => <UsercentricsScript settingsId="1234" version="preview" />
+;() => <UsercentricsScript settingsId="1234" draft={true} />
 
 /* Fixed language code */
 ;() => <UsercentricsScript settingsId="1234" language="fi" />

--- a/src/components/UsercentricsScript.tsx
+++ b/src/components/UsercentricsScript.tsx
@@ -16,10 +16,11 @@ interface UsercentricsScriptProps
     settingsId: string
 
     /**
-     * Whether to run Usercentrics in "production" or "preview" mode.
-     * @default "production"
+     * Whether to run Usercentrics in draft mode
+     * @default `false`
+     * @see https://usercentrics.com/docs/web/implementation/ui/optional-steps/#draft-script
      */
-    version?: 'production' | 'preview'
+    draft?: boolean
 
     src?: never
 }
@@ -41,7 +42,7 @@ export const UsercentricsScript: FC<UsercentricsScriptProps> = ({
     id = 'usercentrics-cmp',
     language,
     settingsId,
-    version,
+    draft = false,
     ...rest
 }) => {
     return (
@@ -50,7 +51,7 @@ export const UsercentricsScript: FC<UsercentricsScriptProps> = ({
             async={'async' in rest ? rest.async : true}
             data-language={language}
             data-settings-id={settingsId}
-            data-version={version}
+            data-draft={draft ? true : undefined}
             id={id}
             src={USERCENTRICS_WEB_CMP_LOADER_SCRIPT_URL}
         />

--- a/tests/components/UsercentricsScript.test.tsx
+++ b/tests/components/UsercentricsScript.test.tsx
@@ -17,9 +17,9 @@ describe('Usercentrics', () => {
             })
 
             it('should render preview attribute', () => {
-                const result = renderToStaticMarkup(<UsercentricsScript settingsId="1234" version="preview" />)
+                const result = renderToStaticMarkup(<UsercentricsScript settingsId="1234" draft={true} />)
 
-                expect(result).toMatch('data-version="preview"')
+                expect(result).toMatch('data-draft="true"')
             })
 
             it('should allow disabling default async prop', () => {


### PR DESCRIPTION
In v3 of CMP `data-version` was replaced by `data-draft`. This PR addresses the change.
